### PR TITLE
Make `timing` API coherent

### DIFF
--- a/api/spec.yaml
+++ b/api/spec.yaml
@@ -36,20 +36,20 @@ components:
       bearerFormat: jwt
       description: 'note: non-oauth scopes are not defined at the securityScheme level'
   schemas:
-    StepEntry:
+    StepLogEntry:
       title: Step log entry
       type: object
       properties:
-        name:
+        id:
           type: string
-          description: Name of the step. Uses GITHUB_ACTION environment variable
+          description: Number of the step 
         exec_time:
           type: uint64
           description: Time took to execute step
         successful:
           type: bool
           description: Was step successful
-    ActionEntry:
+    ActionLogEntry:
       title: Action log entry 
       type: object
       properties:
@@ -79,5 +79,4 @@ components:
         - end
         - successful
         - arch
-        - steps
 

--- a/cmd/srv/main_test.go
+++ b/cmd/srv/main_test.go
@@ -41,6 +41,7 @@ func TestPublishTimingRoute(t *testing.T) {
 		End:         "2023-02-05",
 		ExecTime:    "42",
 		Successfull: true,
+		Arch:        "Arm",
 	}
 
 	b, _ := json.Marshal(body)

--- a/pkg/controllers/publish.go
+++ b/pkg/controllers/publish.go
@@ -9,12 +9,20 @@ import (
 	"github.com/uncleDecart/gha-stat-collector/pkg/models"
 )
 
-type ActionLogEntry struct {
-	Name        string `json:"name" binding:"required"`
-	Start       string `json:"start" binding:"required"`
-	End         string `json:"end" binding:"required"`
+type StepLogEntry struct {
+	Id          uint64 `json:"id" binding:"required"`
 	ExecTime    string `json:"exec_time" binding:"required"`
 	Successfull bool   `json:"successful" binding:"required"`
+}
+
+type ActionLogEntry struct {
+	Name        string         `json:"name" binding:"required"`
+	Start       string         `json:"start" binding:"required"`
+	End         string         `json:"end" binding:"required"`
+	ExecTime    string         `json:"exec_time" binding:"required"`
+	Successfull bool           `json:"successful" binding:"required"`
+	Arch        string         `json:"arch" binding:"required"`
+	Steps       []StepLogEntry `json:"steps"`
 }
 
 func Publish(c *gin.Context) {


### PR DESCRIPTION
Coherent with `spec.yml` and `example.yml` workflow