### PR TITLE
Fix `successful` query parameter for GET /timings

### DIFF
--- a/pkg/controllers/read.go
+++ b/pkg/controllers/read.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -64,7 +65,13 @@ func composeFilterFromQuery(c *gin.Context) bson.M {
 	}
 
 	if successful, ok := c.GetQuery("successful"); ok {
-		filter["successful"] = successful
+		// MongoDb acts strange with boolean filters
+		// see https://stackoverflow.com/questions/18837486/query-for-boolean-field-as-not-true-e-g-either-false-or-non-existent
+		if strings.ToLower(successful) == "true" {
+			filter["successful"] = bson.M{"$ne": false}
+		} else {
+			filter["successful"] = bson.M{"$eq": false}
+		}
 	}
 
 	if arch, ok := c.GetQuery("arch"); ok {


### PR DESCRIPTION
Previously string was not converted to bool
and there's certain peculiarity with handling
bool filters in MongoDB: you can't simply use
`$eq` with false. For more information see

https://stackoverflow.com/questions/18837486/query-for-boolean-field-as-not-true-e-g-either-false-or-non-existent